### PR TITLE
Install packages in batch instead of individually

### DIFF
--- a/src/oteltest/private.py
+++ b/src/oteltest/private.py
@@ -82,9 +82,10 @@ def setup_script_environment(venv_parent: str, script_dir: str, script: str, jso
 
     pip_path = script_venv.path_to_executable("pip")
 
-    for req in oteltest_instance.requirements():
-        logger.info("Will install requirement: '%s'", req)
-        run_subprocess([pip_path, "install", req], logger)
+    reqs = list(oteltest_instance.requirements())
+    if reqs:
+        logger.info("Will install requirements: %s", reqs)
+        run_subprocess([pip_path, "install"] + reqs, logger)
 
     stdout, stderr, returncode = run_python_script(
         start_subprocess, script_dir, script, oteltest_instance, script_venv, logger


### PR DESCRIPTION
Changes package installation from individual `pip install` calls to a single batch installation. Improves installation speed by reducing subprocess overhead, allowing pip to resolve dependencies once.

Before:
```
  for each package:
    pip install package1
    pip install package2
    pip install package3
```
After:
```
  pip install package1 package2 package3
```