### PR TITLE
Fix Windows venv executable path in Venv.path_to_executable

### DIFF
--- a/src/oteltest/private.py
+++ b/src/oteltest/private.py
@@ -237,8 +237,10 @@ class Venv:
         else:
             venv.create(self.venv_dir, with_pip=True)
 
-    def path_to_executable(self, executable_name: str):
-        return f"{self.venv_dir}/bin/{executable_name}"
+    def path_to_executable(self, executable_name: str) -> str:
+        if sys.platform == "win32":
+            return str(Path(self.venv_dir) / "Scripts" / f"{executable_name}.exe")
+        return str(Path(self.venv_dir) / "bin" / executable_name)
 
     def rm(self):
         shutil.rmtree(self.venv_dir)

--- a/tests/test_oteltest.py
+++ b/tests/test_oteltest.py
@@ -4,7 +4,9 @@ import json
 import logging
 import os
 import pickle
+import sys
 from typing import Mapping, Optional, Sequence
+from unittest import mock
 
 import pytest
 from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord
@@ -200,11 +202,26 @@ def test_run_python_script():
         Venv("venv_dir", logger),
         logger,
     )
+    expected_python = Venv("venv_dir", logger).path_to_executable("python")
     assert t.python_script_cmd == [
-        "venv_dir/bin/python",
+        expected_python,
         "script_dir/script",
     ]
     assert t.env == env_store
+
+
+def test_venv_path_to_executable_unix():
+    with mock.patch.object(sys, "platform", "linux"):
+        v = Venv("/my/venv", logging.getLogger())
+        assert v.path_to_executable("pip") == "/my/venv/bin/pip"
+        assert v.path_to_executable("python") == "/my/venv/bin/python"
+
+
+def test_venv_path_to_executable_windows():
+    with mock.patch.object(sys, "platform", "win32"):
+        v = Venv("/my/venv", logging.getLogger())
+        assert v.path_to_executable("pip") == "/my/venv/Scripts/pip.exe"
+        assert v.path_to_executable("python") == "/my/venv/Scripts/python.exe"
 
 
 def test_get_traces(metrics_and_traces_telemetry_fixture):


### PR DESCRIPTION
Use Scripts/<name>.exe on win32 instead of the hardcoded bin/<name> path, which does not exist on Windows. Update test_run_python_script to derive the expected path via Venv rather than a hardcoded string, and add dedicated tests for both Unix and Windows path shapes.