### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install hatch
+      - run: hatch build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` that triggers on `v*` tag pushes
- Builds with `hatch build` and publishes via `pypa/gh-action-pypi-publish` using OIDC trusted publishing (no API tokens needed)
- Requires a `pypi` environment configured in GitHub repo settings

## Pre-requisites

- [x] Trusted publisher configured on PyPI for this repo
- [ ] `pypi` environment created in GitHub repo settings