### PR TITLE
Add regression scenarios for popular instrumentations

### DIFF
--- a/regression_tests/README.md
+++ b/regression_tests/README.md
@@ -10,7 +10,7 @@ release, upstream `main`, or another SDK/instrumentation implementation.
 
 ## Mental Model
 
-- A scenario is the workload, such as `sqlite3_basic.py`.
+- A scenario is the workload, such as `sqlite3_basic.py` or `requests_basic.py`.
 - A subject is the OpenTelemetry SDK/instrumentation set installed for a run.
 - Raw telemetry is the JSON captured by `oteltest`.
 - Normalized telemetry removes unstable request IDs, timestamps, and transport
@@ -20,8 +20,17 @@ release, upstream `main`, or another SDK/instrumentation implementation.
 Available subjects:
 
 - `opentelemetry-python-1-41-1` - default pinned PyPI release subject.
+- `opentelemetry-python-1-42-0` - pinned PyPI release subject for comparing
+  the latest release with the previous known-good behavioral goldens.
 - `opentelemetry-python-main` - installs OpenTelemetry Python and contrib
   packages from upstream `main` branches.
+
+Available scenarios:
+
+- `sqlite3_basic` - sqlite3 DBAPI instrumentation.
+- `requests_basic` - requests HTTP client instrumentation.
+- `sqlalchemy_sqlite_basic` - SQLAlchemy instrumentation over sqlite.
+- `flask_basic` - Flask server instrumentation through a local request.
 
 Run commands from the repository root. Activate the project environment first so
 `oteltest` and the regression tools are on `PATH`:
@@ -72,6 +81,25 @@ Run upstream main against the behavioral golden:
 python regression_tests/tools/run_regression.py sqlite3_basic \
   --subject opentelemetry-python-main \
   --profile behavioral
+```
+
+Run the just-released OpenTelemetry Python 1.42.0 subject against the previous
+known-good behavioral golden:
+
+```shell
+python regression_tests/tools/run_regression.py sqlite3_basic \
+  --subject opentelemetry-python-1-42-0 \
+  --profile behavioral
+```
+
+Run the current scenario set:
+
+```shell
+for scenario in sqlite3_basic requests_basic sqlalchemy_sqlite_basic flask_basic; do
+  python regression_tests/tools/run_regression.py "$scenario" \
+    --subject opentelemetry-python-1-42-0 \
+    --profile behavioral
+done
 ```
 
 Keep raw telemetry after a run by choosing an output directory:

--- a/regression_tests/goldens/behavioral/flask_basic.json
+++ b/regression_tests/goldens/behavioral/flask_basic.json
@@ -1,0 +1,63 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.flask",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.flavor": "1.1",
+            "http.host": "127.0.0.1:<port>",
+            "http.method": "GET",
+            "http.route": "/hello/<name>",
+            "http.scheme": "http",
+            "http.server_name": "127.0.0.1",
+            "http.status_code": "200",
+            "http.target": "/hello/alice?debug=true",
+            "http.user_agent": "python-requests/2.34.2",
+            "net.host.name": "127.0.0.1:<port>",
+            "net.host.port": "<port>",
+            "net.peer.ip": "127.0.0.1",
+            "net.peer.port": "<port>"
+          },
+          "kind": "SPAN_KIND_SERVER",
+          "name": "GET /hello/<name>",
+          "status": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.requests",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.method": "GET",
+            "http.status_code": "200",
+            "http.url": "http://127.0.0.1:<port>/hello/alice?debug=true",
+            "user_agent.original": "python-requests/2.34.2"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "GET",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/behavioral/requests_basic.json
+++ b/regression_tests/goldens/behavioral/requests_basic.json
@@ -1,0 +1,30 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.requests",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.method": "GET",
+            "http.status_code": "200",
+            "http.url": "http://127.0.0.1:<port>/users/42?active=true",
+            "user_agent.original": "python-requests/2.34.2"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "GET",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/behavioral/sqlalchemy_sqlite_basic.json
+++ b/regression_tests/goldens/behavioral/sqlalchemy_sqlite_basic.json
@@ -1,0 +1,110 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.sqlite3",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "db.statement": "PRAGMA read_uncommitted",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "PRAGMA",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.statement": "create table users (id integer primary key, name text)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "create",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.statement": "insert into users (name) values (?)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "insert",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.statement": "select id, name from users where name = ?",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "select",
+          "status": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.sqlalchemy",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "connect",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "create :memory:",
+            "db.statement": "create table users (id integer primary key, name text)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "create :memory:",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "insert :memory:",
+            "db.statement": "insert into users (name) values (?)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "insert :memory:",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "select :memory:",
+            "db.statement": "select id, name from users where name = ?",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "select :memory:",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/behavioral/sqlite3_basic.json
+++ b/regression_tests/goldens/behavioral/sqlite3_basic.json
@@ -4,7 +4,7 @@
   "traces": [
     {
       "resource": {
-        "service.name": "regression-sqlite3-basic",
+        "service.name": "oteltest-regression",
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "opentelemetry"
       },

--- a/regression_tests/goldens/opentelemetry-python-1-41-1/flask_basic.json
+++ b/regression_tests/goldens/opentelemetry-python-1-41-1/flask_basic.json
@@ -1,0 +1,69 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.auto.version": "0.62b1",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.41.1"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.flask",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+        "version": "0.62b1"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.flavor": "1.1",
+            "http.host": "127.0.0.1:<port>",
+            "http.method": "GET",
+            "http.route": "/hello/<name>",
+            "http.scheme": "http",
+            "http.server_name": "127.0.0.1",
+            "http.status_code": "200",
+            "http.target": "/hello/alice?debug=true",
+            "http.user_agent": "python-requests/2.34.2",
+            "net.host.name": "127.0.0.1:<port>",
+            "net.host.port": "<port>",
+            "net.peer.ip": "127.0.0.1",
+            "net.peer.port": "<port>"
+          },
+          "kind": "SPAN_KIND_SERVER",
+          "name": "GET /hello/<name>",
+          "status": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.auto.version": "0.62b1",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.41.1"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.requests",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+        "version": "0.62b1"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.method": "GET",
+            "http.status_code": "200",
+            "http.url": "http://127.0.0.1:<port>/hello/alice?debug=true",
+            "user_agent.original": "python-requests/2.34.2"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "GET",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/opentelemetry-python-1-41-1/requests_basic.json
+++ b/regression_tests/goldens/opentelemetry-python-1-41-1/requests_basic.json
@@ -1,0 +1,33 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.auto.version": "0.62b1",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.41.1"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.requests",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+        "version": "0.62b1"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "http.method": "GET",
+            "http.status_code": "200",
+            "http.url": "http://127.0.0.1:<port>/users/42?active=true",
+            "user_agent.original": "python-requests/2.34.2"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "GET",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/opentelemetry-python-1-41-1/sqlalchemy_sqlite_basic.json
+++ b/regression_tests/goldens/opentelemetry-python-1-41-1/sqlalchemy_sqlite_basic.json
@@ -1,0 +1,120 @@
+{
+  "logs": [],
+  "metrics": [],
+  "traces": [
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.auto.version": "0.62b1",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.41.1"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.sqlite3",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+        "version": "0.62b1"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "db.name": "",
+            "db.statement": "PRAGMA read_uncommitted",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "PRAGMA",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": "",
+            "db.statement": "create table users (id integer primary key, name text)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "create",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": "",
+            "db.statement": "insert into users (name) values (?)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "insert",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": "",
+            "db.statement": "select id, name from users where name = ?",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "select",
+          "status": {}
+        }
+      ]
+    },
+    {
+      "resource": {
+        "service.name": "oteltest-regression",
+        "telemetry.auto.version": "0.62b1",
+        "telemetry.sdk.language": "python",
+        "telemetry.sdk.name": "opentelemetry",
+        "telemetry.sdk.version": "1.41.1"
+      },
+      "scope": {
+        "name": "opentelemetry.instrumentation.sqlalchemy",
+        "schema_url": "https://opentelemetry.io/schemas/1.11.0",
+        "version": "0.62b1"
+      },
+      "spans": [
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "connect",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "create :memory:",
+            "db.statement": "create table users (id integer primary key, name text)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "create :memory:",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "insert :memory:",
+            "db.statement": "insert into users (name) values (?)",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "insert :memory:",
+          "status": {}
+        },
+        {
+          "attributes": {
+            "db.name": ":memory:",
+            "db.operation": "select :memory:",
+            "db.statement": "select id, name from users where name = ?",
+            "db.system": "sqlite"
+          },
+          "kind": "SPAN_KIND_CLIENT",
+          "name": "select :memory:",
+          "status": {}
+        }
+      ]
+    }
+  ]
+}

--- a/regression_tests/goldens/opentelemetry-python-1-41-1/sqlite3_basic.json
+++ b/regression_tests/goldens/opentelemetry-python-1-41-1/sqlite3_basic.json
@@ -4,7 +4,7 @@
   "traces": [
     {
       "resource": {
-        "service.name": "regression-sqlite3-basic",
+        "service.name": "oteltest-regression",
         "telemetry.auto.version": "0.62b1",
         "telemetry.sdk.language": "python",
         "telemetry.sdk.name": "opentelemetry",

--- a/regression_tests/scenarios/flask_basic.py
+++ b/regression_tests/scenarios/flask_basic.py
@@ -1,0 +1,87 @@
+"""
+Regression smoke test: Flask server instrumentation.
+
+This scenario exercises Flask instrumentation against a local Werkzeug server,
+avoiding external network dependencies.
+"""
+
+import sys
+import threading
+from functools import cached_property
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from regression_tests.subjects import load_subject
+
+
+def create_app():
+    from flask import Flask, jsonify
+
+    app = Flask(__name__)
+
+    @app.get("/hello/<name>")
+    def hello(name):
+        return jsonify({"hello": name})
+
+    return app
+
+
+if __name__ == "__main__":
+    import requests
+    from werkzeug.serving import make_server
+
+    app = create_app()
+    server = make_server("127.0.0.1", 0, app)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/hello/alice?debug=true"
+        response = requests.get(url, timeout=5)
+        assert response.status_code == 200
+        assert response.json() == {"hello": "alice"}
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    print("flask workload complete")
+
+
+class FlaskBasicRegressionOtelTest:
+    @cached_property
+    def subject(self):
+        return load_subject()
+
+    def requirements(self):
+        return self.subject.requirements
+
+    def environment_variables(self):
+        return self.subject.environment_variables
+
+    def wrapper_command(self):
+        return self.subject.wrapper_command
+
+    def on_start(self):
+        return 10
+
+    def on_stop(self, tel, stdout: str, stderr: str, returncode: int):
+        from oteltest.telemetry import get_spans, span_attribute_by_name
+
+        assert (
+            returncode == 0
+        ), f"script failed with code {returncode}\nstderr:\n{stderr}"
+        assert "flask workload complete" in stdout
+        assert tel.trace_requests, "no trace requests received"
+
+        spans = get_spans(tel)
+        flask_spans = [
+            span
+            for span in spans
+            if span_attribute_by_name(span, "http.route") == "/hello/<name>"
+            or span_attribute_by_name(span, "url.path") == "/hello/alice"
+        ]
+        assert flask_spans, "expected at least one Flask server span"
+
+    def is_http(self):
+        return True

--- a/regression_tests/scenarios/requests_basic.py
+++ b/regression_tests/scenarios/requests_basic.py
@@ -1,0 +1,88 @@
+"""
+Regression smoke test: requests HTTP client instrumentation.
+
+This scenario exercises the popular requests instrumentation against a local
+HTTP server so it does not depend on external network access.
+"""
+
+import json
+import sys
+import threading
+from functools import cached_property
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from regression_tests.subjects import load_subject
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = json.dumps({"ok": True, "path": self.path}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+if __name__ == "__main__":
+    import requests
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+
+    try:
+        url = f"http://127.0.0.1:{server.server_port}/users/42?active=true"
+        response = requests.get(url, timeout=5)
+        assert response.status_code == 200
+        assert response.json()["path"] == "/users/42?active=true"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    print("requests workload complete")
+
+
+class RequestsBasicRegressionOtelTest:
+    @cached_property
+    def subject(self):
+        return load_subject()
+
+    def requirements(self):
+        return self.subject.requirements
+
+    def environment_variables(self):
+        return self.subject.environment_variables
+
+    def wrapper_command(self):
+        return self.subject.wrapper_command
+
+    def on_start(self):
+        return 10
+
+    def on_stop(self, tel, stdout: str, stderr: str, returncode: int):
+        from oteltest.telemetry import get_spans, span_attribute_by_name
+
+        assert (
+            returncode == 0
+        ), f"script failed with code {returncode}\nstderr:\n{stderr}"
+        assert "requests workload complete" in stdout
+        assert tel.trace_requests, "no trace requests received"
+
+        spans = get_spans(tel)
+        http_spans = [
+            span
+            for span in spans
+            if span_attribute_by_name(span, "http.method") == "GET"
+            or span_attribute_by_name(span, "http.request.method") == "GET"
+        ]
+        assert http_spans, "expected at least one requests HTTP span"
+
+    def is_http(self):
+        return True

--- a/regression_tests/scenarios/sqlalchemy_sqlite_basic.py
+++ b/regression_tests/scenarios/sqlalchemy_sqlite_basic.py
@@ -1,0 +1,79 @@
+"""
+Regression smoke test: SQLAlchemy instrumentation over sqlite.
+
+This scenario covers SQLAlchemy's DB layer without requiring an external
+database service.
+"""
+
+import sys
+from functools import cached_property
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from regression_tests.subjects import load_subject
+
+if __name__ == "__main__":
+    from sqlalchemy import create_engine, text
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("create table users (id integer primary key, name text)"))
+            conn.execute(
+                text("insert into users (name) values (:name)"), {"name": "alice"}
+            )
+            rows = conn.execute(
+                text("select id, name from users where name = :name"),
+                {"name": "alice"},
+            ).fetchall()
+            assert rows == [(1, "alice")], rows
+    finally:
+        engine.dispose()
+
+    print("sqlalchemy workload complete")
+
+
+class SqlalchemySqliteBasicRegressionOtelTest:
+    @cached_property
+    def subject(self):
+        return load_subject()
+
+    def requirements(self):
+        return self.subject.requirements
+
+    def environment_variables(self):
+        return self.subject.environment_variables
+
+    def wrapper_command(self):
+        return self.subject.wrapper_command
+
+    def on_start(self):
+        return 10
+
+    def on_stop(self, tel, stdout: str, stderr: str, returncode: int):
+        from oteltest.telemetry import count_spans, get_spans, span_attribute_by_name
+
+        assert (
+            returncode == 0
+        ), f"script failed with code {returncode}\nstderr:\n{stderr}"
+        assert "sqlalchemy workload complete" in stdout
+        assert tel.trace_requests, "no trace requests received"
+
+        spans = get_spans(tel)
+        assert count_spans(tel) >= 1, "expected at least one SQLAlchemy span"
+
+        db_spans = [
+            span
+            for span in spans
+            if span_attribute_by_name(span, "db.system") in {"sqlite", "sqlite3"}
+            or span_attribute_by_name(span, "db.system.name") in {"sqlite", "sqlite3"}
+        ]
+        assert db_spans, "expected at least one span with db.system=sqlite"
+
+        span_names = {span.name.lower() for span in db_spans}
+        assert any(
+            "select" in name for name in span_names
+        ), f"expected a SELECT db span, got: {sorted(span_names)}"
+
+    def is_http(self):
+        return True

--- a/regression_tests/subjects/opentelemetry-python-1-42-0.json
+++ b/regression_tests/subjects/opentelemetry-python-1-42-0.json
@@ -1,14 +1,14 @@
 {
-  "name": "opentelemetry-python-1-41-1",
+  "name": "opentelemetry-python-1-42-0",
   "requirements": [
-    "opentelemetry-api==1.41.1",
-    "opentelemetry-sdk==1.41.1",
-    "opentelemetry-distro==0.62b1",
-    "opentelemetry-exporter-otlp-proto-http==1.41.1",
-    "opentelemetry-instrumentation-flask==0.62b1",
-    "opentelemetry-instrumentation-requests==0.62b1",
-    "opentelemetry-instrumentation-sqlalchemy==0.62b1",
-    "opentelemetry-instrumentation-sqlite3==0.62b1",
+    "opentelemetry-api==1.42.0",
+    "opentelemetry-sdk==1.42.0",
+    "opentelemetry-distro==0.63b0",
+    "opentelemetry-exporter-otlp-proto-http==1.42.0",
+    "opentelemetry-instrumentation-flask==0.63b0",
+    "opentelemetry-instrumentation-requests==0.63b0",
+    "opentelemetry-instrumentation-sqlalchemy==0.63b0",
+    "opentelemetry-instrumentation-sqlite3==0.63b0",
     "Flask==3.1.2",
     "requests==2.34.2",
     "SQLAlchemy==2.0.49"

--- a/regression_tests/subjects/opentelemetry-python-main.json
+++ b/regression_tests/subjects/opentelemetry-python-main.json
@@ -10,10 +10,16 @@
     "opentelemetry-instrumentation @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=opentelemetry-instrumentation",
     "opentelemetry-distro @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=opentelemetry-distro",
     "opentelemetry-instrumentation-dbapi @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-dbapi",
-    "opentelemetry-instrumentation-sqlite3 @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-sqlite3"
+    "opentelemetry-instrumentation-flask @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-flask",
+    "opentelemetry-instrumentation-requests @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-requests",
+    "opentelemetry-instrumentation-sqlalchemy @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-sqlalchemy",
+    "opentelemetry-instrumentation-sqlite3 @ git+https://github.com/open-telemetry/opentelemetry-python-contrib.git@main#subdirectory=instrumentation/opentelemetry-instrumentation-sqlite3",
+    "Flask==3.1.2",
+    "requests==2.34.2",
+    "SQLAlchemy==2.0.49"
   ],
   "environment_variables": {
-    "OTEL_SERVICE_NAME": "regression-sqlite3-basic",
+    "OTEL_SERVICE_NAME": "oteltest-regression",
     "OTEL_TRACES_EXPORTER": "otlp",
     "OTEL_METRICS_EXPORTER": "none",
     "OTEL_LOGS_EXPORTER": "none",

--- a/regression_tests/tools/normalize_telemetry.py
+++ b/regression_tests/tools/normalize_telemetry.py
@@ -3,11 +3,30 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
 
 PROFILE_CHOICES = ("strict", "behavioral")
+LOCALHOST_URL_PORT_RE = re.compile(r"(https?://(?:127\.0\.0\.1|localhost)):\d+")
+LOCALHOST_HOST_PORT_RE = re.compile(r"((?:127\.0\.0\.1|localhost)):\d+")
+URL_ATTRIBUTES = {
+    "http.url",
+    "url.full",
+}
+HOST_PORT_ATTRIBUTES = {
+    "http.host",
+    "net.host.name",
+}
+PORT_ATTRIBUTES = {
+    "client.port",
+    "net.host.port",
+    "net.peer.port",
+    "network.local.port",
+    "network.peer.port",
+    "server.port",
+}
 BEHAVIORAL_RESOURCE_EXCLUDES = {
     "telemetry.auto.version",
     "telemetry.sdk.version",
@@ -104,10 +123,22 @@ def normalize_status(status: dict[str, Any]) -> dict[str, str]:
 
 def normalize_attributes(attributes: list[dict[str, Any]]) -> dict[str, Any]:
     return {
-        attribute["key"]: normalize_value(attribute.get("value", {}))
+        attribute["key"]: normalize_attribute_value(
+            attribute["key"], normalize_value(attribute.get("value", {}))
+        )
         for attribute in sorted(attributes, key=lambda item: item.get("key", ""))
         if "key" in attribute
     }
+
+
+def normalize_attribute_value(key: str, value: Any) -> Any:
+    if key in URL_ATTRIBUTES and isinstance(value, str):
+        return LOCALHOST_URL_PORT_RE.sub(r"\1:<port>", value)
+    if key in HOST_PORT_ATTRIBUTES and isinstance(value, str):
+        return LOCALHOST_HOST_PORT_RE.sub(r"\1:<port>", value)
+    if key in PORT_ATTRIBUTES:
+        return "<port>"
+    return value
 
 
 def normalize_value(value: dict[str, Any]) -> Any:

--- a/tests/test_regression_normalizer.py
+++ b/tests/test_regression_normalizer.py
@@ -189,3 +189,81 @@ def test_behavioral_profile_removes_empty_db_name_attributes():
         "custom.empty": "",
         "db.statement": "select 1",
     }
+
+
+def test_normalize_telemetry_scrubs_loopback_url_ports():
+    raw = {
+        "trace_requests": [
+            {
+                "pbreq": {
+                    "resourceSpans": [
+                        {
+                            "resource": {"attributes": []},
+                            "scopeSpans": [
+                                {
+                                    "scope": {"name": "scope", "version": "1.0"},
+                                    "spans": [
+                                        {
+                                            "name": "GET",
+                                            "kind": "SPAN_KIND_CLIENT",
+                                            "attributes": [
+                                                {
+                                                    "key": "http.url",
+                                                    "value": {
+                                                        "stringValue": (
+                                                            "http://127.0.0.1:51234/"
+                                                            "users/42?active=true"
+                                                        )
+                                                    },
+                                                },
+                                                {
+                                                    "key": "url.full",
+                                                    "value": {
+                                                        "stringValue": (
+                                                            "http://localhost:49876/"
+                                                            "hello/alice"
+                                                        )
+                                                    },
+                                                },
+                                                {
+                                                    "key": "http.host",
+                                                    "value": {
+                                                        "stringValue": (
+                                                            "127.0.0.1:51234"
+                                                        )
+                                                    },
+                                                },
+                                                {
+                                                    "key": "server.port",
+                                                    "value": {"intValue": 51234},
+                                                },
+                                                {
+                                                    "key": "net.host.name",
+                                                    "value": {
+                                                        "stringValue": (
+                                                            "localhost:49876"
+                                                        )
+                                                    },
+                                                },
+                                            ],
+                                            "status": {},
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+
+    normalized = normalize_telemetry(raw)
+
+    assert normalized["traces"][0]["spans"][0]["attributes"] == {
+        "http.host": "127.0.0.1:<port>",
+        "http.url": "http://127.0.0.1:<port>/users/42?active=true",
+        "net.host.name": "localhost:<port>",
+        "server.port": "<port>",
+        "url.full": "http://localhost:<port>/hello/alice",
+    }

--- a/tests/test_regression_subjects.py
+++ b/tests/test_regression_subjects.py
@@ -15,10 +15,9 @@ def test_load_default_subject(monkeypatch):
     assert subject.name == DEFAULT_SUBJECT
     assert subject.name == "opentelemetry-python-1-41-1"
     assert "opentelemetry-api==1.41.1" in subject.requirements
+    assert "opentelemetry-instrumentation-requests==0.62b1" in subject.requirements
     assert subject.wrapper_command == "opentelemetry-instrument"
-    assert (
-        subject.environment_variables["OTEL_SERVICE_NAME"] == "regression-sqlite3-basic"
-    )
+    assert subject.environment_variables["OTEL_SERVICE_NAME"] == "oteltest-regression"
 
 
 def test_load_subject_from_environment(monkeypatch):
@@ -31,6 +30,14 @@ def test_load_subject_from_environment(monkeypatch):
     assert any(
         "opentelemetry-python-contrib.git@main" in req for req in subject.requirements
     )
+
+
+def test_load_1_42_release_subject():
+    subject = load_subject("opentelemetry-python-1-42-0")
+
+    assert subject.name == "opentelemetry-python-1-42-0"
+    assert "opentelemetry-sdk==1.42.0" in subject.requirements
+    assert "opentelemetry-instrumentation-sqlalchemy==0.63b0" in subject.requirements
 
 
 def test_load_unknown_subject_lists_available_subjects(monkeypatch):


### PR DESCRIPTION
## Summary
- add regression scenarios for requests, SQLAlchemy over sqlite, and Flask
- add 1.41.1-derived strict and behavioral goldens for the new scenarios
- add an OpenTelemetry Python 1.42.0 subject and document running release comparisons
- normalize loopback host/port noise so local HTTP scenario goldens stay deterministic

## Validation
- `hatch run test`
- 1.41.1 strict regression checks passed for sqlite3, requests, SQLAlchemy, and Flask
- 1.42.0 behavioral regression checks passed for sqlite3, requests, SQLAlchemy, and Flask against the 1.41.1-derived goldens
- `git diff --check`