### PR TITLE
Add nightly upstream regression workflow

### DIFF
--- a/.github/workflows/upstream-regression.yml
+++ b/.github/workflows/upstream-regression.yml
@@ -1,0 +1,53 @@
+name: upstream regression
+
+on:
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  opentelemetry-python-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e .
+
+      - name: Run behavioral regression scenarios
+        shell: bash
+        run: |
+          set +e
+          status=0
+
+          for scenario in sqlite3_basic requests_basic sqlalchemy_sqlite_basic flask_basic; do
+            echo "::group::$scenario"
+            python regression_tests/tools/run_regression.py "$scenario" \
+              --subject opentelemetry-python-main \
+              --profile behavioral \
+              --output-dir "regression-artifacts/$scenario"
+            rc=$?
+            echo "::endgroup::"
+
+            if [ "$rc" -ne 0 ]; then
+              status=1
+            fi
+          done
+
+          exit "$status"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: regression-artifacts
+          path: regression-artifacts/
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a scheduled GitHub Actions workflow for upstream OpenTelemetry Python main regression checks
- run the current regression scenario set against `opentelemetry-python-main` with the `behavioral` profile
- upload raw regression telemetry artifacts on every run for failure triage
- allow manual runs with `workflow_dispatch`

## Notes
- schedule is `17 9 * * *` UTC
- the workflow runs scenarios sequentially and reports failure after all scenarios have had a chance to run

## Validation
- `git diff --check`